### PR TITLE
[NEW] perf: Optimize `CollectFields` calculation for non-primitive array fields

### DIFF
--- a/graphql/collect_fields_cache_integration_test.go
+++ b/graphql/collect_fields_cache_integration_test.go
@@ -1,0 +1,183 @@
+package graphql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+const collectFieldsSchemaSDL = `
+    interface Node {
+        name: String!
+        email: String
+    }
+
+    type User implements Node {
+        name: String!
+        email: String
+    }
+
+    type Admin implements Node {
+        name: String!
+        email: String
+        secret: String
+    }
+
+    type Query {
+        search: [Node!]!
+        user: User!
+    }
+`
+
+var collectFieldsSchema = gqlparser.MustLoadSchema(&ast.Source{
+	Name:  "collectFieldsCache",
+	Input: collectFieldsSchemaSDL,
+})
+
+func TestCollectFieldsCache_InterfaceResult(t *testing.T) {
+	const query = `
+        query {
+            search {
+                name
+                ... on User {
+                    email
+                }
+                ... on Admin {
+                    secret
+                }
+            }
+        }
+    `
+
+	doc := gqlparser.MustLoadQuery(collectFieldsSchema, query)
+	op := doc.Operations[0]
+	searchField := op.SelectionSet[0].(*ast.Field)
+
+	opCtx := &OperationContext{
+		RawQuery:  query,
+		Variables: nil,
+		Doc:       doc,
+		Operation: op,
+	}
+
+	userFields := CollectFields(opCtx, searchField.SelectionSet, []string{"User"})
+	adminFields := CollectFields(opCtx, searchField.SelectionSet, []string{"Admin"})
+
+	require.ElementsMatch(t, []string{"name", "email"}, fieldNames(userFields))
+	require.ElementsMatch(t, []string{"name", "secret"}, fieldNames(adminFields))
+	require.Equal(t, 2, opCtx.collectFieldsCache.Len())
+}
+
+func TestCollectFieldsCache_AliasResult(t *testing.T) {
+	const query = `
+        query {
+            user1: user { name }
+            user2: user { email }
+        }
+    `
+
+	doc := gqlparser.MustLoadQuery(collectFieldsSchema, query)
+	op := doc.Operations[0]
+
+	opCtx := &OperationContext{
+		RawQuery:  query,
+		Variables: nil,
+		Doc:       doc,
+		Operation: op,
+	}
+
+	fields := CollectFields(opCtx, op.SelectionSet, nil)
+	require.Equal(t, 1, opCtx.collectFieldsCache.Len())
+	require.Len(t, fields, 2)
+
+	expected := []struct {
+		alias        string
+		expectedName string
+	}{
+		{alias: "user1", expectedName: "name"},
+		{alias: "user2", expectedName: "email"},
+	}
+
+	for _, check := range expected {
+		var matched bool
+		for _, f := range fields {
+			alias := f.Alias
+			if alias == "" {
+				alias = f.Name
+			}
+			if alias == check.alias {
+				require.Equal(t, []string{check.expectedName}, selectionNames(f.Selections))
+				matched = true
+				break
+			}
+		}
+		require.True(t, matched, "expected alias %q not found", check.alias)
+	}
+}
+
+func TestCollectFieldsCache_DirectiveResult(t *testing.T) {
+	const query = `
+        query Test($includeEmail: Boolean!, $skipName: Boolean!) {
+            search {
+                ... on User {
+                    name @skip(if: $skipName)
+                    email @include(if: $includeEmail)
+                }
+            }
+        }
+    `
+
+	run := func(vars map[string]any) ([]CollectedField, int) {
+		doc := gqlparser.MustLoadQuery(collectFieldsSchema, query)
+		op := doc.Operations[0]
+		searchField := op.SelectionSet[0].(*ast.Field)
+
+		opCtx := &OperationContext{
+			RawQuery:  query,
+			Variables: vars,
+			Doc:       doc,
+			Operation: op,
+		}
+
+		first := CollectFields(opCtx, searchField.SelectionSet, []string{"User"})
+		second := CollectFields(opCtx, searchField.SelectionSet, []string{"User"})
+		require.Equal(t, first, second)
+		return first, opCtx.collectFieldsCache.Len()
+	}
+
+	fieldsA, cacheA := run(map[string]any{"includeEmail": false, "skipName": false})
+	require.Equal(t, 1, cacheA)
+	require.Equal(t, []string{"name"}, fieldNames(fieldsA))
+
+	fieldsB, cacheB := run(map[string]any{"includeEmail": true, "skipName": true})
+	require.Equal(t, 1, cacheB)
+	require.Equal(t, []string{"email"}, fieldNames(fieldsB))
+
+	fieldsC, cacheC := run(map[string]any{"includeEmail": false, "skipName": true})
+	require.Equal(t, 1, cacheC)
+	require.Len(t, fieldsC, 0)
+
+	fieldsD, cacheD := run(map[string]any{"includeEmail": true, "skipName": false})
+	require.Equal(t, 1, cacheD)
+	require.ElementsMatch(t, []string{"name", "email"}, fieldNames(fieldsD))
+}
+
+func fieldNames(fields []CollectedField) []string {
+	names := make([]string, 0, len(fields))
+	for _, f := range fields {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func selectionNames(sel ast.SelectionSet) []string {
+	names := make([]string, 0, len(sel))
+	for _, s := range sel {
+		if f, ok := s.(*ast.Field); ok {
+			names = append(names, f.Name)
+		}
+	}
+	return names
+}

--- a/graphql/collect_fields_cache_integration_test.go
+++ b/graphql/collect_fields_cache_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/validator/rules"
 )
 
 const collectFieldsSchemaSDL = `
@@ -51,7 +52,7 @@ func TestCollectFieldsCache_InterfaceResult(t *testing.T) {
         }
     `
 
-	doc := gqlparser.MustLoadQuery(collectFieldsSchema, query)
+	doc := gqlparser.MustLoadQueryWithRules(collectFieldsSchema, query, rules.NewDefaultRules())
 	op := doc.Operations[0]
 	searchField := op.SelectionSet[0].(*ast.Field)
 
@@ -78,7 +79,7 @@ func TestCollectFieldsCache_AliasResult(t *testing.T) {
         }
     `
 
-	doc := gqlparser.MustLoadQuery(collectFieldsSchema, query)
+	doc := gqlparser.MustLoadQueryWithRules(collectFieldsSchema, query, rules.NewDefaultRules())
 	op := doc.Operations[0]
 
 	opCtx := &OperationContext{
@@ -130,7 +131,7 @@ func TestCollectFieldsCache_DirectiveResult(t *testing.T) {
     `
 
 	run := func(vars map[string]any) ([]CollectedField, int) {
-		doc := gqlparser.MustLoadQuery(collectFieldsSchema, query)
+		doc := gqlparser.MustLoadQueryWithRules(collectFieldsSchema, query, rules.NewDefaultRules())
 		op := doc.Operations[0]
 		searchField := op.SelectionSet[0].(*ast.Field)
 
@@ -157,7 +158,7 @@ func TestCollectFieldsCache_DirectiveResult(t *testing.T) {
 
 	fieldsC, cacheC := run(map[string]any{"includeEmail": false, "skipName": true})
 	require.Equal(t, 1, cacheC)
-	require.Len(t, fieldsC, 0)
+	require.Empty(t, fieldsC)
 
 	fieldsD, cacheD := run(map[string]any{"includeEmail": true, "skipName": false})
 	require.Equal(t, 1, cacheD)

--- a/graphql/collect_fields_cache_store.go
+++ b/graphql/collect_fields_cache_store.go
@@ -1,0 +1,76 @@
+package graphql
+
+import (
+	"hash/fnv"
+	"sync"
+	"unsafe"
+
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+// collectFieldsCacheKey is the cache key for CollectFields results.
+type collectFieldsCacheKey struct {
+	selectionData unsafe.Pointer // Pointer to the underlying SelectionSet data
+	selectionLen  int            // Length of the selection set
+	satisfiesHash uint64         // Hash of the satisfies array
+}
+
+// collectFieldsCacheStore manages CollectFields cache entries safely.
+type collectFieldsCacheStore struct {
+	mu    sync.RWMutex
+	items map[collectFieldsCacheKey][]CollectedField
+}
+
+// Get returns the cached result for the key if present.
+func (s *collectFieldsCacheStore) Get(key collectFieldsCacheKey) ([]CollectedField, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.items == nil {
+		return nil, false
+	}
+	val, ok := s.items[key]
+	return val, ok
+}
+
+// Add stores the value when absent and returns the cached value.
+func (s *collectFieldsCacheStore) Add(key collectFieldsCacheKey, value []CollectedField) []CollectedField {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.items == nil {
+		s.items = make(map[collectFieldsCacheKey][]CollectedField)
+	}
+
+	if existing, ok := s.items[key]; ok {
+		return existing
+	}
+	s.items[key] = value
+	return value
+}
+
+// Len returns the number of cached entries.
+func (s *collectFieldsCacheStore) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.items)
+}
+
+// makeCollectFieldsCacheKey generates a cache key for CollectFields.
+func makeCollectFieldsCacheKey(selSet ast.SelectionSet, satisfies []string) collectFieldsCacheKey {
+	var dataPtr unsafe.Pointer
+	if len(selSet) > 0 {
+		dataPtr = unsafe.Pointer(unsafe.SliceData(selSet))
+	}
+
+	h := fnv.New64a()
+	for _, s := range satisfies {
+		h.Write([]byte(s))
+		h.Write([]byte{0})
+	}
+
+	return collectFieldsCacheKey{
+		selectionData: dataPtr,
+		selectionLen:  len(selSet),
+		satisfiesHash: h.Sum64(),
+	}
+}

--- a/graphql/context_operation.go
+++ b/graphql/context_operation.go
@@ -27,6 +27,8 @@ type OperationContext struct {
 	RootResolverMiddleware RootFieldMiddleware
 
 	Stats Stats
+
+	collectFieldsCache collectFieldsCacheStore
 }
 
 func (c *OperationContext) Validate(ctx context.Context) error {


### PR DESCRIPTION
## Relates to
https://github.com/99designs/gqlgen/pull/3868

This PR improves performance "**without modifying template files"**. 🎊 

## Description
Hello there, thank you for maintaining this excellent library. 
I have discovered a performance issue that significantly impacts applications at scale.

When marshaling non-primitive array type fields to JSON, the `CollectFields` operation is executed. 
This operation always returns the same result for a given field, yet the current implementation recalculates it for every element in the array.
This causes performance to degrade proportionally to both the number of array elements and the number of fields being queried.
For large-scale GraphQL applications, this can lead to serious performance bottlenecks.

This PR addresses the issue by calculating `CollectFields` once and reusing the result across all array elements. Benchmark results show significant improvements !!! (**28.8% reduction in execution time, 9.6% reduction in memory usage** 🎉)

As this is my first time modifying generated code, there may be some issues with the implementation. While the benchmark results are promising, I would greatly appreciate any reviews or suggestions to ensure this change meets the quality standards for merging into master branch.

### Simple Benchmark

- `$len` items
- 20 fields

| len | before | after | implovement |
|-----|---------|--------|--------|
| 1 | 562.7 ns | 718.0 ns | +27.6% |
| 10 | 5643 ns | 845.1 ns | **-85.0%** |
| 100 | 56267 ns | 2128 ns | **-96.2%** |
| 1000 | 573901 ns | 15403 ns | **-97.3%** |
| 10000 | 5698006 ns | 146784 ns | **-97.4%** |

<details>
<summary>details 1</summary>

```go
package graphql

import (
	"strconv"
	"testing"

	"github.com/vektah/gqlparser/v2/ast"
	"github.com/vektah/gqlparser/v2/parser"
)

const benchmarkCollectFieldsQuery = `
query BenchmarkUsers {
	users {
		field1
		field2
		field3
		field4
		field5
		field6
		field7
		field8
		field9
		field10
		field11
		field12
		field13
		field14
		field15
		field16
		field17
		field18
		field19
		field20
	}
}`

var (
	benchmarkDoc      *ast.QueryDocument
	usersSelectionSet ast.SelectionSet
)

func init() {
	doc, err := parser.ParseQuery(&ast.Source{Input: benchmarkCollectFieldsQuery})
	if err != nil {
		panic(err)
	}

	op := doc.Operations.ForName("BenchmarkUsers")
	if op == nil {
		panic("missing BenchmarkUsers operation")
	}

	var found bool
	for _, sel := range op.SelectionSet {
		if fld, ok := sel.(*ast.Field); ok && fld.Name == "users" {
			usersSelectionSet = fld.SelectionSet
			found = true
			break
		}
	}

	if !found {
		panic("missing users field in benchmark query")
	}

	benchmarkDoc = doc
}

func BenchmarkCollectFieldsUsers(b *testing.B) {
	cases := []int{1, 10, 100, 1000, 10000}

	for _, listLen := range cases {
		listLen := listLen
		b.Run("len_"+strconv.Itoa(listLen), func(b *testing.B) {
			benchmarkCollectFieldsUsers(b, listLen)
		})
	}
}

func benchmarkCollectFieldsUsers(b *testing.B, listLen int) {
	satisfies := []string{"User"}

	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		reqCtx := &OperationContext{
			Doc:       benchmarkDoc,
			Variables: map[string]any{},
		}

		for j := 0; j < listLen; j++ {
			if len(CollectFields(reqCtx, usersSelectionSet, satisfies)) == 0 {
				b.Fatal("unexpected empty collected fields")
			}
		}
	}
}
```

</details>

### Real-World Benchmark

- `$len` items
- 20 fields

| len | Before | After | Improvement |
|-----|---------|--------|--------|
| 1 | 25736 ns | 24853 ns | **-3.4%** |
| 10 | 84757 ns | 82422 ns | **-2.8%** |
| 100 | 502873 ns | 467409 ns | **-7.1%** |
| 1000 | 5175136 ns | 4874696 ns | **-5.8%** |
| 10000 | 36449460 ns | 32573729 ns | **-10.6%** |

<details>

<summary> details 2 </summary>

```go
package benchmark

import (
	"context"
	"fmt"
	"strconv"
	"testing"

	"github.com/99designs/gqlgen/codegen/testserver/benchmark/generated"
	"github.com/99designs/gqlgen/codegen/testserver/benchmark/generated/models"
	"github.com/99designs/gqlgen/graphql"
	"github.com/99designs/gqlgen/graphql/executor"
)

const collectFieldsBenchmarkQuery = `
query BenchmarkUsers {
	users {
		edges {
			node {
				field1
				field2
				field3
				field4
				field5
				field6
				field7
				field8
				field9
				field10
				field11
				field12
				field13
				field14
				field15
				field16
				field17
				field18
				field19
				field20
			}
		}
	}
}
`

func BenchmarkCollectFieldsUsers(b *testing.B) {
	cases := []int{1, 10, 100, 1000, 10000}

	for _, listLen := range cases {
		listLen := listLen
		b.Run("len_"+strconv.Itoa(listLen), func(b *testing.B) {
			benchmarkCollectFieldsUsers(b, listLen)
		})
	}
}

func benchmarkCollectFieldsUsers(b *testing.B, listLen int) {
	resolvers := &Stub{}

	connection := newUserConnection(listLen)

	resolvers.QueryResolver.Users = func(ctx context.Context, query *string, first *int, last *int, before *string, after *string, orderBy models.UserOrderBy) (*models.UserConnection, error) {
		return connection, nil
	}

	exec := executor.New(generated.NewExecutableSchema(generated.Config{
		Resolvers: resolvers,
	}))

	params := &graphql.RawParams{
		Query:         collectFieldsBenchmarkQuery,
		OperationName: "BenchmarkUsers",
	}

	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		ctx := graphql.StartOperationTrace(context.Background())
		opCtx, errs := exec.CreateOperationContext(ctx, params)
		if errs != nil {
			b.Fatalf("create operation context: %v", errs)
		}

		resultHandler, execCtx := exec.DispatchOperation(ctx, opCtx)
		if resp := resultHandler(execCtx); resp == nil || len(resp.Data) == 0 {
			b.Fatal("empty response")
		}
	}
}

func newUserConnection(listLen int) *models.UserConnection {
	edges := make([]*models.UserEdge, listLen)
	for i := 0; i < listLen; i++ {
		edges[i] = &models.UserEdge{
			Cursor: fmt.Sprintf("cursor_%d", i),
			Node: &models.User{
				FirstName: fmt.Sprintf("First_%d", i),
				LastName:  fmt.Sprintf("Last_%d", i),
				Email:     fmt.Sprintf("user_%d@example.com", i),
				Field1:    fmt.Sprintf("Field1_%d", i),
				Field2:    fmt.Sprintf("Field2_%d", i),
				Field3:    fmt.Sprintf("Field3_%d", i),
				Field4:    fmt.Sprintf("Field4_%d", i),
				Field5:    fmt.Sprintf("Field5_%d", i),
				Field6:    fmt.Sprintf("Field6_%d", i),
				Field7:    fmt.Sprintf("Field7_%d", i),
				Field8:    fmt.Sprintf("Field8_%d", i),
				Field9:    fmt.Sprintf("Field9_%d", i),
				Field10:   fmt.Sprintf("Field10_%d", i),
				Field11:   fmt.Sprintf("Field11_%d", i),
				Field12:   fmt.Sprintf("Field12_%d", i),
				Field13:   fmt.Sprintf("Field13_%d", i),
				Field14:   fmt.Sprintf("Field14_%d", i),
				Field15:   fmt.Sprintf("Field15_%d", i),
				Field16:   fmt.Sprintf("Field16_%d", i),
				Field17:   fmt.Sprintf("Field17_%d", i),
				Field18:   fmt.Sprintf("Field18_%d", i),
				Field19:   fmt.Sprintf("Field19_%d", i),
				Field20:   fmt.Sprintf("Field20_%d", i),
			},
		}
	}

	return &models.UserConnection{
		Edges: edges,
		PageInfo: &models.PageInfo{
			HasNextPage:     false,
			HasPreviousPage: false,
			StartCursor:     "cursor_0",
			EndCursor:       fmt.Sprintf("cursor_%d", max(0, listLen-1)),
		},
		TotalCount: listLen,
	}
}

func max(a, b int) int {
	if a > b {
		return a
	}
	return b
}
```

</details>

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
